### PR TITLE
Do not redirect direct access front-names

### DIFF
--- a/app/code/community/Webbhuset/Geoip/Model/Observer.php
+++ b/app/code/community/Webbhuset/Geoip/Model/Observer.php
@@ -26,6 +26,15 @@ class Webbhuset_Geoip_Model_Observer
             return;
         }
 
+        $request        = Mage::app()->getRequest();
+        $routeName      = $request->getRouteName();
+        $route          = Mage::app()->getFrontController()->getRouterByRoute($routeName);
+        $frontName      = $route->getFrontNameByRoute($routeName);
+
+        if ($request->isDirectAccessFrontendName($frontName)) {
+            return;
+        }
+
         $this->checkNoRoute();
 
         $geoIP          = Mage::getSingleton('geoip/country');
@@ -33,7 +42,6 @@ class Webbhuset_Geoip_Model_Observer
         $response       = Mage::app()->getResponse();
         $session        = Mage::getSingleton('core/session');
         $result         = new Varien_Object(array('should_proceed' => 1));
-
 
         Mage::dispatchEvent('wh_geoip_redirect_store_before', array('result' => $result));
 


### PR DESCRIPTION
Modules may register it's frontname as direct access (such as Mage_Api) and therefore should not be affected by any GeoIp redirect. 