### PR TITLE
Fix class name typo

### DIFF
--- a/app/code/community/Webbhuset/Geoip/Block/Adminhtml/Notifications.php
+++ b/app/code/community/Webbhuset/Geoip/Block/Adminhtml/Notifications.php
@@ -1,6 +1,6 @@
 <?php
 
-class Webbhuse_Geoip_Block_Adminhtml_Notifications
+class Webbhuset_Geoip_Block_Adminhtml_Notifications
     extends Mage_Adminhtml_Block_Template
 {
     public function checkFilePermissions()


### PR DESCRIPTION
This typo causes "Fatal error: Cannot declare class Webbhuse_Geoip_Block_Adminhtml_Notifications, because the name is already in use in app/code/community/Webbhuset/Geoip/Block/Adminhtml/Notifications.php on line 0"

Magento version 1.9.3.7 with security patches